### PR TITLE
Nested-objects-encoding

### DIFF
--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -1243,6 +1243,9 @@ function mapValues(object, iterator) {
   const result = {};
   Object.keys(object).forEach(key => {
     result[key] = iterator(object[key]);
+    if (result[key] && JSON.stringify(result[key]).includes(`"__type"`)) {
+      result[key] = mapValues(object[key], iterator);
+    }
   });
   return result;
 }


### PR DESCRIPTION
Carries over changes from parse-community/parse-server#8209 to fix encoding of nested objects, specifically dates.

